### PR TITLE
Update deprecated GitHub actions

### DIFF
--- a/.github/workflows/multi-parallel-private.yml
+++ b/.github/workflows/multi-parallel-private.yml
@@ -163,7 +163,7 @@ jobs:
           zip -r results-${CLEANED_RUN}-${CLEANED_CLIENT}.zip results
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: results-${{ env.CLEANED_RUN }}-${{ env.CLEANED_CLIENT }}
           path: results-${{ env.CLEANED_RUN }}-${{ env.CLEANED_CLIENT }}.zip
@@ -188,7 +188,7 @@ jobs:
       - name: Install python dependencies
         run: pip install -r requirements.txt
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: combined-results
           merge-multiple: true
@@ -227,7 +227,7 @@ jobs:
           zip -r reports.zip reports
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: reports
           path: reports.zip

--- a/.github/workflows/multi-parallel.yml
+++ b/.github/workflows/multi-parallel.yml
@@ -154,7 +154,7 @@ jobs:
           zip -r results-${CLEANED_RUN}-${CLEANED_CLIENT}.zip results
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: results-${{ env.CLEANED_RUN }}-${{ env.CLEANED_CLIENT }}
           path: results-${{ env.CLEANED_RUN }}-${{ env.CLEANED_CLIENT }}.zip
@@ -179,7 +179,7 @@ jobs:
       - name: Install python dependencies
         run: pip install -r requirements.txt
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: combined-results
           merge-multiple: true
@@ -211,7 +211,7 @@ jobs:
           zip -r reports.zip reports
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: reports
           path: reports.zip


### PR DESCRIPTION
- Updates `upload-artifact`, `download-artifact` to v4: v3 is [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) and forces build crash.