### PR TITLE
Added a feature to use performance docker image with hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Generated env files
 scripts/**/.env
+
+.history/

--- a/run_and_post_metrics.sh
+++ b/run_and_post_metrics.sh
@@ -69,6 +69,8 @@ fi
 # Run commands in an infinite loop
 while true; do
   git pull
+  # Update performance images
+  python update_performance_images.py
   # Run the benchmark testing using specified warmup file
   PROMETHEUS_ENDPOINT="$PROMETHEUS_ENDPOINT" PROMETHEUS_USERNAME="$PROMETHEUS_USERNAME" PROMETHEUS_PASSWORD="$PROMETHEUS_PASSWORD" \
     bash run.sh -t "tests-vm/" -w "$WARMUP_FILE" -r1
@@ -78,4 +80,7 @@ while true; do
 
   # Clean up the reports directory
   rm -rf reports/
+
+  # Revert images.yml to original state
+  python update_performance_images.py --revert
 done

--- a/update_performance_images.py
+++ b/update_performance_images.py
@@ -1,0 +1,90 @@
+import yaml
+import requests
+import os
+import sys
+import re
+
+IMAGES_YAML_PATH = os.path.join(os.path.dirname(__file__), "images.yaml")
+
+def load_images_yaml(path):
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+def save_images_yaml(data, path):
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+def get_latest_performance_tag(image):
+    """
+    Query Docker Hub API for the latest 'performance-*' tag for the given image.
+    """
+    if "/" not in image:
+        # Not a valid Docker Hub image
+        return None
+    namespace, repo = image.split("/", 1)
+    url = f"https://hub.docker.com/v2/repositories/{namespace}/{repo}/tags?page_size=2&name=performance"
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        results = resp.json().get("results", [])
+        perf_tags = [r["name"] for r in results if r["name"].startswith("performance-")]
+        if not perf_tags:
+            return None
+        # Sort tags by name descending (assuming lexicographical order is sufficient)
+        perf_tags.sort(reverse=True)
+        return perf_tags[0]
+    except Exception as e:
+        print(f"Error fetching tags for {image}: {e}")
+        return None
+
+def revert_performance_tags():
+    images_yaml = load_images_yaml(IMAGES_YAML_PATH)
+    images = images_yaml.get("images", {})
+    updated = False
+
+    for key, value in images.items():
+        # Replace :performance-xxxxxxx with :performance
+        m = re.match(r"^(.*:)(performance-[a-zA-Z0-9]+)$", value)
+        if m:
+            new_value = m.group(1) + "performance"
+            if new_value != value:
+                print(f"Reverting {key}: {value} -> {new_value}")
+                images[key] = new_value
+                updated = True
+
+    if updated:
+        save_images_yaml(images_yaml, IMAGES_YAML_PATH)
+        print("images.yaml reverted to :performance tags.")
+    else:
+        print("No performance-* tags to revert.")
+
+def main():
+    if "--revert" in sys.argv:
+        revert_performance_tags()
+        return
+
+    images_yaml = load_images_yaml(IMAGES_YAML_PATH)
+    images = images_yaml.get("images", {})
+    updated = False
+
+    for key, value in images.items():
+        if value.endswith(":performance"):
+            image_ref = value.rsplit(":", 1)[0]
+            latest_tag = get_latest_performance_tag(image_ref)
+            if latest_tag:
+                new_value = f"{image_ref}:{latest_tag}"
+                if new_value != value:
+                    print(f"Updating {key}: {value} -> {new_value}")
+                    images[key] = new_value
+                    updated = True
+            else:
+                print(f"No performance-* tag found for {image_ref}, skipping.")
+
+    if updated:
+        save_images_yaml(images_yaml, IMAGES_YAML_PATH)
+        print("images.yaml updated.")
+    else:
+        print("No updates made to images.yaml.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`python update_performance_images.py` will check `images.yml` file and if the docker tag ends with `perforamce`, the script will query docker API and get last image with hash e.g. `performance-02659f2`. After that the script will update the file.

Run `python update_performance_images.py --revert` will revert the tags back to `performance`