### PR TITLE
Add postgress bulk insert

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -104,15 +104,14 @@ def get_gas_table(client_results, client, test_cases, gas_set, method, metadata)
         gas_table_norm[test_case] = ['' for _ in range(9)]
         # test_case_name, description, N, MGgas/s, mean, max, min. std, p50, p95, p99
         # (norm) title, description, N , max, min, p50, p95, p99
+        timestamp = client_results[client][test_case]["timestamp"] if client_results[client][test_case] and "timestamp" in client_results[client][test_case] else 0
+        gas_table_norm[test_case][8] = timestamp
         if test_case in metadata:
             gas_table_norm[test_case][0] = metadata[test_case]['Title']
             gas_table_norm[test_case][7] = metadata[test_case]['Description']
-            timestamp = getattr(client_results[client][test_case], 'timestamp', 0) if client_results[client][test_case] else 0
-            gas_table_norm[test_case][8] = timestamp
         else:
             gas_table_norm[test_case][0] = test_case
             gas_table_norm[test_case][7] = 'Description not found on metadata file'
-            gas_table_norm[test_case][8] = 0
         if len(results_norm) == 0:
             gas_table_norm[test_case][1] = f'0'
             gas_table_norm[test_case][2] = f'0'


### PR DESCRIPTION
1. Improved inserting data to DB (from 1,5 minutes to 2 seconds)

```
2025-07-10 19:13:47,524 - INFO - fill_postgres_db - get_db_connection - Successfully connected to database 'monitoring' on perfnet.core.nethermind.dev.
2025-07-10 19:13:47,549 - INFO - fill_postgres_db - main - Successfully read and extracted text content from reports/index.html
2025-07-10 19:13:47,549 - INFO - fill_postgres_db - main - Parsing computer specifications from: reports
2025-07-10 19:13:47,549 - INFO - fill_postgres_db - get_computer_specs - Reading computer specs from HTML: reports/index.html
2025-07-10 19:13:47,569 - INFO - fill_postgres_db - main - Found clients: ['nethermind']
2025-07-10 19:13:47,570 - INFO - fill_postgres_db - main - --- Processing client: nethermind ---
2025-07-10 19:13:47,570 - INFO - fill_postgres_db - extract_client_version_from_text_content - Successfully extracted version 'performance-c0289c6' for client 'nethermind' from line: 'Nethermind - ethpandaops/nethermind:performance-c0289c6 - Benchmarking Report'
2025-07-10 19:13:47,571 - INFO - fill_postgres_db - populate_data_for_client - Processing raw results for client: nethermind from reports/raw_results_nethermind.csv
2025-07-10 19:13:48,038 - INFO - fill_postgres_db - bulk_insert_records - Bulk inserted 405 records into gas_limit_benchmarks2
2025-07-10 19:13:48,039 - INFO - fill_postgres_db - main - Inserted 405 records for client nethermind.
2025-07-10 19:13:48,102 - INFO - fill_postgres_db - main - 
Successfully committed all changes. Total records inserted: 405.
2025-07-10 19:13:48,102 - INFO - fill_postgres_db - main - PostgreSQL connection closed.
```

2. Fixed issue when `start_time` column was always 0 