### PR TITLE
Remove hardcoded copying of genesis.json

### DIFF
--- a/scripts/ethrex/run.sh
+++ b/scripts/ethrex/run.sh
@@ -1,7 +1,5 @@
 # Prepare ethrex image that we will use on the script
 cd scripts/ethrex
-
-cp genesis.json /tmp/genesis.json
 cp jwtsecret /tmp/jwtsecret
 
 docker compose up -d


### PR DESCRIPTION
There was a hardcoded copy of the genesis.json file in the run.sh script. This one overrode the zkevmgenesis.json file, which is in Cancun, preventing ethrex from running eest tests. After this, tests like keccak can run correctly.