### PR TITLE
make: only clone if nethermind directory does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: prepare_tools clean
 
 prepare_tools:
-	git clone https://github.com/NethermindEth/nethermind nethermind
+	@if [ ! -d nethermind ]; then \
+		git clone https://github.com/NethermindEth/nethermind nethermind;\
+	fi
 	cd nethermind && git checkout e1857d7ca6613ccdc40973899290f565f367e235 && cd ..
 	dotnet build ./nethermind/tools/Nethermind.Tools.Kute -c Release --property WarningLevel=0
 


### PR DESCRIPTION
If Nethermind build fails, Makefile tries to re-clone Nethermind which will throw since the directory already exists. This will only clone if the directory does not exist.