### PR TITLE
feat: add jochemnet chain support to stateful generator

### DIFF
--- a/.github/workflows/generate-stateful-tests.yml
+++ b/.github/workflows/generate-stateful-tests.yml
@@ -19,6 +19,7 @@ on:
         options:
           - mainnet
           - perf-devnet-3
+          - jochemnet
         default: "mainnet"
       nethermind_image:
         description: "Nethermind Docker image"
@@ -36,6 +37,7 @@ on:
           - ""
           - "generator-amsterdam-mainnet.json"
           - "generator-amsterdam-perf-devnet-3.json"
+          - "generator-amsterdam-jochemnet.json"
         default: ""
       eest_repo:
         description: "execution-specs repository"
@@ -54,7 +56,7 @@ on:
         required: true
         default: "30,60,90,120,150,180,210,240,270,300"
       gas_bump_count:
-        description: "Gas bump count (-1 = chain default: 5000 for perf-devnet-3, 10000 for mainnet)"
+        description: "Gas bump count (-1 = chain default: 5000 for perf-devnet-3/jochemnet, 10000 for mainnet)"
         required: true
         default: "-1"
       parameter_filter:
@@ -274,6 +276,12 @@ jobs:
               EXECUTION_CHAIN="mainnet"
               STUBS_FILE="execution-specs/tests/benchmark/stateful/stubs/stubs_bloatnet.json"
               ;;
+            jochemnet)
+              SNAPSHOT_DIR_NM="/mnt/sda/jochemnet/nethermind"
+              SNAPSHOT_DIR_WARMUP="$SNAPSHOT_DIR_NM"
+              EXECUTION_CHAIN="mainnet"
+              STUBS_FILE="execution-specs/tests/benchmark/stateful/stubs/stubs_bloatnet.json"
+              ;;
             *)
               echo "Unsupported chain: $CFG_CHAIN" >&2
               exit 1
@@ -293,7 +301,7 @@ jobs:
           WARMUP_DIR="${PAYLOAD_DIR}_warmup"
           GAS_BUMP_COUNT="$CFG_GAS_BUMP_COUNT"
           if [[ "$GAS_BUMP_COUNT" == "-1" ]]; then
-            if [[ "$CFG_CHAIN" == "perf-devnet-3" ]]; then
+            if [[ "$CFG_CHAIN" == "perf-devnet-3" || "$CFG_CHAIN" == "jochemnet" ]]; then
               GAS_BUMP_COUNT="5000"
             else
               GAS_BUMP_COUNT="10000"

--- a/.github/workflows/release-workstream.yml
+++ b/.github/workflows/release-workstream.yml
@@ -82,9 +82,9 @@ jobs:
               DEFAULT_FORK="Osaka"
               DEFAULT_CHAINSPEC=""
               FULL_MATRIX='[
-                {"mode":"compute","chain":"mainnet"},
+                {"mode":"compute","chain":"jochemnet"},
                 {"mode":"compute","chain":"perf-devnet-3"},
-                {"mode":"stateful","chain":"mainnet"},
+                {"mode":"stateful","chain":"jochemnet"},
                 {"mode":"stateful","chain":"perf-devnet-3"}
               ]'
               ;;
@@ -94,8 +94,9 @@ jobs:
               DEFAULT_FORK="Amsterdam"
               DEFAULT_CHAINSPEC=""
               FULL_MATRIX='[
-                {"mode":"compute","chain":"mainnet","chainspec":"generator-amsterdam-mainnet.json"},
+                {"mode":"compute","chain":"jochemnet","chainspec":"generator-amsterdam-jochemnet.json"},
                 {"mode":"compute","chain":"perf-devnet-3","chainspec":"generator-amsterdam-perf-devnet-3.json"},
+                {"mode":"stateful","chain":"jochemnet","chainspec":"generator-amsterdam-jochemnet.json"},
                 {"mode":"stateful","chain":"perf-devnet-3","chainspec":"generator-amsterdam-perf-devnet-3.json"}
               ]'
               ;;
@@ -105,9 +106,9 @@ jobs:
               DEFAULT_FORK="Osaka"
               DEFAULT_CHAINSPEC=""
               FULL_MATRIX='[
-                {"mode":"compute","chain":"mainnet"},
+                {"mode":"compute","chain":"jochemnet"},
                 {"mode":"compute","chain":"perf-devnet-3"},
-                {"mode":"stateful","chain":"mainnet"},
+                {"mode":"stateful","chain":"jochemnet"},
                 {"mode":"stateful","chain":"perf-devnet-3"}
               ]'
               ;;
@@ -117,8 +118,9 @@ jobs:
               DEFAULT_FORK="Amsterdam"
               DEFAULT_CHAINSPEC=""
               FULL_MATRIX='[
-                {"mode":"compute","chain":"mainnet","chainspec":"generator-amsterdam-mainnet.json"},
+                {"mode":"compute","chain":"jochemnet","chainspec":"generator-amsterdam-jochemnet.json"},
                 {"mode":"compute","chain":"perf-devnet-3","chainspec":"generator-amsterdam-perf-devnet-3.json"},
+                {"mode":"stateful","chain":"jochemnet","chainspec":"generator-amsterdam-jochemnet.json"},
                 {"mode":"stateful","chain":"perf-devnet-3","chainspec":"generator-amsterdam-perf-devnet-3.json"}
               ]'
               ;;

--- a/eest_stateful_generator.py
+++ b/eest_stateful_generator.py
@@ -415,7 +415,27 @@ def generate_opcode_trace_json(testing_dir: Path, opcode_tracing_dir: Path, outp
         print(f"[WARN] Testing directory {testing_dir} does not exist")
         return
 
+    print(f"[DEBUG] Opcode tracing directory: {opcode_tracing_dir} (exists={opcode_tracing_dir.exists()})")
+    if opcode_tracing_dir.exists():
+        all_files = sorted(opcode_tracing_dir.rglob("*"))
+        print(f"[DEBUG] All files in opcode tracing dir ({len(all_files)} total):")
+        for f in all_files:
+            try:
+                size = f.stat().st_size if f.is_file() else -1
+            except Exception:
+                size = -1
+            print(f"[DEBUG]   {f.relative_to(opcode_tracing_dir)}  ({size} bytes)")
+        cumulative_files = sorted(opcode_tracing_dir.rglob("opcode-trace-all-*.json"))
+        if cumulative_files:
+            for cf in cumulative_files:
+                try:
+                    preview = cf.read_text(encoding="utf-8")[:2000]
+                    print(f"[DEBUG] Cumulative trace file {cf.name} preview:\n{preview}\n[DEBUG] ... (truncated)")
+                except Exception as e:
+                    print(f"[DEBUG] Could not read {cf.name}: {e}")
+
     trace_files = sorted(opcode_tracing_dir.rglob("opcode-trace-block-*.json"))
+    print(f"[DEBUG] Matched opcode-trace-block-*.json files: {len(trace_files)}")
     trace_entries: List[Dict[str, Any]] = []
     seen_signatures: set[Any] = set()
 

--- a/eest_stateful_generator.py
+++ b/eest_stateful_generator.py
@@ -415,27 +415,7 @@ def generate_opcode_trace_json(testing_dir: Path, opcode_tracing_dir: Path, outp
         print(f"[WARN] Testing directory {testing_dir} does not exist")
         return
 
-    print(f"[DEBUG] Opcode tracing directory: {opcode_tracing_dir} (exists={opcode_tracing_dir.exists()})")
-    if opcode_tracing_dir.exists():
-        all_files = sorted(opcode_tracing_dir.rglob("*"))
-        print(f"[DEBUG] All files in opcode tracing dir ({len(all_files)} total):")
-        for f in all_files:
-            try:
-                size = f.stat().st_size if f.is_file() else -1
-            except Exception:
-                size = -1
-            print(f"[DEBUG]   {f.relative_to(opcode_tracing_dir)}  ({size} bytes)")
-        cumulative_files = sorted(opcode_tracing_dir.rglob("opcode-trace-all-*.json"))
-        if cumulative_files:
-            for cf in cumulative_files:
-                try:
-                    preview = cf.read_text(encoding="utf-8")[:2000]
-                    print(f"[DEBUG] Cumulative trace file {cf.name} preview:\n{preview}\n[DEBUG] ... (truncated)")
-                except Exception as e:
-                    print(f"[DEBUG] Could not read {cf.name}: {e}")
-
     trace_files = sorted(opcode_tracing_dir.rglob("opcode-trace-block-*.json"))
-    print(f"[DEBUG] Matched opcode-trace-block-*.json files: {len(trace_files)}")
     trace_entries: List[Dict[str, Any]] = []
     seen_signatures: set[Any] = set()
 

--- a/scripts/genesisfiles/nethermind/generator-amsterdam-jochemnet.json
+++ b/scripts/genesisfiles/nethermind/generator-amsterdam-jochemnet.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be1dd3acca279fbb0d57c19e41fbd8532036f079550cbbb7f4014376d1ffff76
-size 1176911
+oid sha256:8f87645576b15b2ff63465cae37674145d4c5c1d700e34205d29ea4673e9ef7c
+size 1207623

--- a/scripts/genesisfiles/nethermind/generator-amsterdam-jochemnet.json
+++ b/scripts/genesisfiles/nethermind/generator-amsterdam-jochemnet.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be1dd3acca279fbb0d57c19e41fbd8532036f079550cbbb7f4014376d1ffff76
+size 1176911


### PR DESCRIPTION
- Add jochemnet to workflow chain choices and chainspec options
- Add snapshot path mapping (/mnt/sda/jochemnet/nethermind)
- Use bloatnet stubs and 5000 gas bump count (same as perf-devnet-3)
- Copy perf-devnet-3 chainspec as jochemnet starting point