### PR TITLE
Fix restart-before-testing run flag parsing

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1009,7 +1009,7 @@ update_execution_time() {
   echo "Updated execution time for $client: $timestamp"
 }
 
-while getopts "T:t:g:c:r:i:o:f:n:B:O:S:R:FW:K:E:" opt; do
+while getopts "T:t:g:c:r:i:o:f:n:B:O:S:RFW:K:E:" opt; do
   case $opt in
     T) TEST_PATHS_JSON="$OPTARG" ;;
     t) LEGACY_TEST_PATH="$OPTARG" ;;


### PR DESCRIPTION
## Summary
- Fix `run.sh` `getopts` parsing so `-R` is treated as a boolean flag
- This makes the new `restart_before_testing` workflow input usable

## Testing
- Ran `git diff --check`
- Attempted `bash -n run.sh`; local Windows checkout has CRLF line endings, so bash reports CRLF syntax noise before parsing the script body