### PR TITLE
feat(workflows): add jochemnet support to repricing-nethermind

### DIFF
--- a/.github/workflows/repricing-nethermind.yml
+++ b/.github/workflows/repricing-nethermind.yml
@@ -89,8 +89,10 @@ jobs:
           ALL_TARGETS=(
             "repricings_compute/mainnet|mainnet"
             "repricings_compute/perf-devnet-3|perf-devnet-3"
+            "repricings_compute/jochemnet|jochemnet"
             "repricings_stateful/mainnet|mainnet"
             "repricings_stateful/perf-devnet-3|perf-devnet-3"
+            "repricings_stateful/jochemnet|jochemnet"
           )
 
           if [ -z "$tests_input" ] || [ "$tests_input" = "all" ]; then
@@ -409,9 +411,19 @@ jobs:
           CUSTOM_OVERLAY="${{ inputs.overlay_root }}"
           GENESIS_FILE="${{ inputs.genesis_file }}"
 
+          # Auto-resolve genesis from fork+network when caller didn't override.
+          # Convention: scripts/genesisfiles/nethermind/generator-<fork>-<network>.json
+          if [[ -z "$GENESIS_FILE" ]]; then
+            CANDIDATE="generator-${FORK_NAME}-${NETWORK}.json"
+            if [[ -f "scripts/genesisfiles/nethermind/$CANDIDATE" ]]; then
+              GENESIS_FILE="$CANDIDATE"
+              echo "Auto-resolved genesis from fork+network: $GENESIS_FILE"
+            fi
+          fi
+
           GENESIS_ARGS=()
           if [[ -n "$GENESIS_FILE" ]]; then
-            echo "Using custom genesis: $GENESIS_FILE"
+            echo "Using genesis: $GENESIS_FILE"
             GENESIS_ARGS=(-g "$GENESIS_FILE")
           fi
 


### PR DESCRIPTION
## Summary
- Add `repricings_compute/jochemnet` and `repricings_stateful/jochemnet` to the workflow's `ALL_TARGETS` so `test=all` includes jochemnet and `test=repricings_compute` / `test=repricings_stateful` convenience matching picks it up.
- Auto-resolve `genesis_file` from `fork`+`network` via the `generator-<fork>-<network>.json` convention when the caller didn't pass one. Removes the foot-gun where users had to remember the chainspec filename for every dispatch.

## Why
- The v5.2.0 release already ships `generated-tests-{compute,stateful}-jochemnet.tar.gz` and `scripts/genesisfiles/nethermind/generator-amsterdam-jochemnet.json` is present in the repo — only the workflow was missing the wiring.
- Without auto-resolve, every dispatch had to repeat `-f genesis_file=generator-amsterdam-<network>.json`, even though it's deterministic from the network.

## Backward compatibility
- Explicit `genesis_file` input still wins (checked before auto-resolve).
- Existing mainnet / perf-devnet-3 dispatches that omit `genesis_file` will now auto-resolve to the same filenames the input description already documents, so behavior is unchanged for those dispatches that previously had to pass it explicitly.

## Test plan
- [ ] Dispatch with `test=repricings_compute/jochemnet`, fork=amsterdam, no `genesis_file` — expect job log to show `Auto-resolved genesis from fork+network: generator-amsterdam-jochemnet.json`.
- [ ] Dispatch with `test=all`, fork=amsterdam — expect 6 matrix entries (3 networks × {compute, stateful}).
- [ ] Dispatch with `test=repricings_compute/perf-devnet-3` + explicit `genesis_file=generator-amsterdam-perf-devnet-3.json` — expect job log to show `Using genesis: …` (no auto-resolve override).
- [ ] Requires `/mnt/sda/jochemnet/nethermind` snapshot on the `stateful-generator` runner; if absent the run will fail fast at overlay setup. Confirm with infra before merging.