### PR TITLE
feat: add 'chain' input to run clients on embedded configs

### DIFF
--- a/.github/workflows/repricing-nethermind.yml
+++ b/.github/workflows/repricing-nethermind.yml
@@ -61,6 +61,9 @@ on:
       nethermind_extra_flags:
         description: "Extra Nethermind CLI flags appended to the container command (e.g. '--Pruning.Mode=None --FlatDb.Enabled=true')"
         default: ''
+      chain:
+        description: "Embedded client config to run (e.g. 'mainnet'): starts Nethermind with --config <chain> and skips genesis selection entirely"
+        default: ''
 
 permissions:
   contents: read
@@ -427,6 +430,16 @@ jobs:
             GENESIS_ARGS=(-g "$GENESIS_FILE")
           fi
 
+          # Embedded config mode: --config <chain> on the client, no genesis at all.
+          CHAIN_INPUT="${{ inputs.chain }}"
+          CHAIN_ARGS=()
+          if [[ -n "$CHAIN_INPUT" ]]; then
+            echo "Using embedded client config: $CHAIN_INPUT (genesis selection skipped)"
+            GENESIS_FILE=""
+            GENESIS_ARGS=()
+            CHAIN_ARGS=(-H "$CHAIN_INPUT")
+          fi
+
           EXTRA_FLAGS_ARGS=()
           if [[ -n "$CFG_NETHERMIND_EXTRA_FLAGS" ]]; then
             echo "Extra Nethermind flags: $CFG_NETHERMIND_EXTRA_FLAGS"
@@ -449,6 +462,7 @@ jobs:
               -f "$EFFECTIVE_FILTER" \
               -K "$FORK_NAME" \
               "${GENESIS_ARGS[@]}" \
+              "${CHAIN_ARGS[@]}" \
               "${WARMUP_ARGS[@]}" \
               "${EXTRA_FLAGS_ARGS[@]}"
           else
@@ -463,6 +477,7 @@ jobs:
               -o "$WARMUP_COUNT" \
               -f "$EFFECTIVE_FILTER" \
               -K "$FORK_NAME" \
+              "${CHAIN_ARGS[@]}" \
               "${WARMUP_ARGS[@]}" \
               "${EXTRA_FLAGS_ARGS[@]}"
           fi

--- a/run.sh
+++ b/run.sh
@@ -27,6 +27,7 @@ RPC_READINESS_MAX_ATTEMPTS="${RPC_READINESS_MAX_ATTEMPTS:-50}"
 OVERLAY_MOUNT_EXTRA_OPTS="${OVERLAY_MOUNT_EXTRA_OPTS:-}"
 OVERLAY_USE_VOLATILE="${OVERLAY_USE_VOLATILE:-false}"
 EXTRA_CLIENT_FLAGS=""
+CHAIN=""
 
 # Prevent inherited low API pin from older docker clients/wrappers.
 unset DOCKER_API_VERSION
@@ -1009,7 +1010,7 @@ update_execution_time() {
   echo "Updated execution time for $client: $timestamp"
 }
 
-while getopts "T:t:g:c:r:i:o:f:n:B:O:S:R:FW:K:E:" opt; do
+while getopts "T:t:g:c:r:i:o:f:n:B:O:S:R:FW:K:E:H:" opt; do
   case $opt in
     T) TEST_PATHS_JSON="$OPTARG" ;;
     t) LEGACY_TEST_PATH="$OPTARG" ;;
@@ -1028,7 +1029,8 @@ while getopts "T:t:g:c:r:i:o:f:n:B:O:S:R:FW:K:E:" opt; do
     W) WARMUP_OPCODES_PATH="$OPTARG" ;;
     K) FORK_NAME="${OPTARG,,}" ;;
     E) EXTRA_CLIENT_FLAGS="$OPTARG" ;;
-    *) echo "Usage: $0 [-t test_path] [-c clients] [-r runs] [-i images] [-o opcodesWarmupCount] [-f filter] [-n network] [-B snapshot_root] [-O runtime_root] [-S snapshot_backend(overlay|zfs)] [-F skipForkchoice] [-W warmup_opcodes_path] [-K fork] [-E extra_client_flags]" >&2
+    H) CHAIN="$OPTARG" ;;
+    *) echo "Usage: $0 [-t test_path] [-c clients] [-r runs] [-i images] [-o opcodesWarmupCount] [-f filter] [-n network] [-B snapshot_root] [-O runtime_root] [-S snapshot_backend(overlay|zfs)] [-F skipForkchoice] [-W warmup_opcodes_path] [-K fork] [-E extra_client_flags] [-H chain]" >&2
        exit 1 ;;
   esac
 done
@@ -1283,6 +1285,9 @@ for run in $(seq 1 $RUNS); do
       setup_cmd+=(--genesisPath "$genesis_path")
     fi
     setup_cmd+=(--volumeName "$volume_name")
+    if [ -n "$CHAIN" ]; then
+      setup_cmd+=(--chain "$CHAIN")
+    fi
     if [ -n "$EXTRA_CLIENT_FLAGS" ]; then
       setup_cmd+=(--extraFlags "$EXTRA_CLIENT_FLAGS")
     fi

--- a/setup_node.py
+++ b/setup_node.py
@@ -43,11 +43,13 @@ CLIENT_METADATA: Dict[str, Dict[str, Any]] = {
                 "env": "NETHERMIND_CONFIG_FLAG",
                 "custom": "--config=none",
                 "network": lambda net: f"--config={resolve_nethermind_config_network(net)}",
+                "chain": lambda chain: f"--config={chain}",
             },
             {
                 "env": "NETHERMIND_GENESIS_FLAG",
                 "custom": "--Init.ChainSpecPath=/tmp/chainspec/chainspec.json",
                 "network": "",
+                "chain": "",
             },
         ],
         "extra_env": {},
@@ -187,7 +189,18 @@ def get_metadata(client: str) -> Dict[str, Any]:
     return CLIENT_METADATA.get(client, DEFAULT_CLIENT_METADATA)
 
 
-def evaluate_flag(flag_entry: Dict[str, Any], network: Optional[str], use_custom_genesis: bool) -> str:
+def evaluate_flag(
+    flag_entry: Dict[str, Any],
+    network: Optional[str],
+    use_custom_genesis: bool,
+    chain: Optional[str] = None,
+) -> str:
+    if chain:
+        value = flag_entry.get("chain", "")
+        if callable(value):
+            return value(chain)
+        return value or ""
+
     key = "custom" if use_custom_genesis else "network"
     value = flag_entry.get(key, "")
     if callable(value):
@@ -228,6 +241,7 @@ def set_env(
     metadata: Dict[str, Any],
     volume_name: Optional[str],
     extra_flags: Optional[str] = None,
+    chain: Optional[str] = None,
 ):
     run_path_obj = Path(run_path).resolve()
     if not run_path_obj.is_dir():
@@ -254,7 +268,7 @@ def set_env(
         env_key = flag_entry.get("env")
         if not env_key:
             continue
-        evaluated = evaluate_flag(flag_entry, network, use_custom_genesis)
+        evaluated = evaluate_flag(flag_entry, network, use_custom_genesis, chain)
         if evaluated:
             env_map[env_key] = evaluated
 
@@ -307,6 +321,11 @@ def main():
     )
     parser.add_argument("--genesisPath", type=str, help="Custom genesis file path")
     parser.add_argument("--network", type=str, help="Named network to resolve default genesis")
+    parser.add_argument(
+        "--chain",
+        type=str,
+        help="Embedded client config to run (e.g. mainnet); skips genesis selection entirely",
+    )
     parser.add_argument(
         "--dataDir",
         type=str,
@@ -364,9 +383,14 @@ def main():
     run_path = str((REPO_ROOT / "scripts" / client_without_tag).resolve())
 
     metadata = get_metadata(client_without_tag)
-    use_custom_genesis = bool(genesis_path)
+    chain = args.chain
+    use_custom_genesis = bool(genesis_path) and not chain
 
-    if network and use_custom_genesis:
+    if chain:
+        print(f"[info] Using embedded client config: {chain} (genesis selection skipped)")
+        if genesis_path:
+            print("[warn] --genesisPath ignored because --chain was provided")
+    elif network and use_custom_genesis:
         print(f"[info] Using custom genesis with network context: {network}")
 
     genesis_target: Path = metadata["target"]
@@ -390,6 +414,7 @@ def main():
         metadata=metadata,
         volume_name=volume_name,
         extra_flags=args.extraFlags,
+        chain=chain,
     )
 
     # Start client


### PR DESCRIPTION
Adds a `chain` workflow input (plumbed through `run.sh -H` and `setup_node.py --chain`). When set (e.g. `mainnet`), Nethermind starts with `--config <chain>` and genesis selection is skipped entirely — both the workflow's fork+network auto-resolution and setup_node's genesis copy/mount flag.

Why: the stateful-generator pipeline runs its Nethermind node on the embedded mainnet chainspec (`Loading ChainSpec from embedded resources`, genesis `0xd4e567…`), so the perf-devnet-3 snapshots are rooted at the embedded-mainnet chain. Benchmark runs must match that. Today a no-genesis run resolves to `--config=<network>` (no such embedded config, e.g. `perf-devnet-3`) or falls back to the zkevm default genesis — the node crashes at startup either way, which is why osaka-repricings runs on `main` never get past node boot.

Usage:
```
gh workflow run repricing-nethermind.yml --ref main   -f test=repricings_stateful/perf-devnet-3 -f fork=osaka   -f release_tag=osaka-repricings-v1.2.0 -f chain=mainnet   -f snapshot_root='/mnt/sda/<<NETWORK>>/nethermind' ...
```