### PR TITLE
Inject contract deployments

### DIFF
--- a/eest_stateful_generator.py
+++ b/eest_stateful_generator.py
@@ -555,6 +555,50 @@ def _has_phase_payloads(payload_dir: Path) -> bool:
             continue
     return False
 
+def _promote_deploy_setup_to_global(payloads_dir: Path, setup_global_file: Path, deploy_filter: str) -> bool:
+    """Relocate the predeployment scenario's setup payload into the top-level
+    setup-global-test.txt base file.
+
+    The deploy run (`test_deploy_existing_contracts`) builds its blocks on the
+    funding head and writes them under payloads/setup/<deploy>.txt (its
+    pre-funding + CREATE2 deployments). We move those lines into
+    setup-global-test.txt so they are replayed — like gas-bump.txt and
+    funding.txt — ahead of every test, and we drop the deploy's per-scenario
+    files so it is never treated as a normal measured test. The benchmark
+    scenarios then anchor on this base head (see the addon's
+    _read_hook_block_for_first_setup) and build on top of the predeployments.
+
+    Returns True if a deploy payload was promoted.
+    """
+    setup_dir = payloads_dir / "setup"
+    testing_dir = payloads_dir / "testing"
+    deploy_setup_files = (
+        sorted(f for f in setup_dir.glob("*.txt") if deploy_filter in f.stem)
+        if setup_dir.is_dir() else []
+    )
+    if not deploy_setup_files:
+        print(f"[WARN] No deploy setup payload found to promote (filter={deploy_filter!r}); "
+              "predeployments will not be in the base.")
+        return False
+    lines: list = []
+    for f in deploy_setup_files:
+        for ln in f.read_text(encoding="utf-8").splitlines():
+            if ln.strip():
+                lines.append(ln)
+    setup_global_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"[INFO] Promoted deploy predeployments -> {setup_global_file.name} "
+          f"({len(deploy_setup_files)} file(s), {len(lines)} lines).")
+    removed = 0
+    for d in (setup_dir, testing_dir):
+        if d.is_dir():
+            for f in list(d.glob("*.txt")):
+                if deploy_filter in f.stem:
+                    f.unlink(missing_ok=True)
+                    removed += 1
+    print(f"[INFO] Removed {removed} per-scenario deploy payload file(s) "
+          "(predeployments now live in the base).")
+    return True
+
 def is_mounted(mount_point: Path) -> bool:
     try:
         with open("/proc/mounts", "r") as f:
@@ -1720,6 +1764,10 @@ def main():
             )
             if deploy_proc.returncode != 0:
                 raise subprocess.CalledProcessError(deploy_proc.returncode, deploy_cmd)
+            # Move the predeployment payloads into the setup-global-test.txt base
+            # so they replay ahead of every test (like gas-bump/funding) and the
+            # benchmark scenarios build on top of them, rather than being a test.
+            _promote_deploy_setup_to_global(payloads_dir, setup_global_file, deployment_test_filter)
 
         testing_dir = payloads_dir / "testing"
         seen_testing_files: set[str] = set()

--- a/eest_stateful_generator.py
+++ b/eest_stateful_generator.py
@@ -1611,6 +1611,11 @@ def main():
             if mode_key not in mode_map:
                 raise SystemExit(f"Unsupported --eest-mode value: {args.eest_mode!r}")
             eest_mode = mode_map[mode_key]
+        eoa_start = "103835740027347086785932208981225044632444623980288738833340492242305523519088"
+        # Global-setup test that deploys the CREATE2 receiver contracts.
+        # It runs in a dedicated execute remote invocation before the
+        # benchmarks and is excluded from the main run.
+        deployment_test_filter = "test_deploy_existing_contracts"
         uv_cmd = [
             "uv", "run", "execute", "remote", "-v",
             f"--fork={args.fork}",
@@ -1627,7 +1632,7 @@ def main():
             uv_cmd.append(f"--gas-benchmark-values={args.gas_benchmark_values}")
         uv_cmd += [
             "--tx-wait-timeout", "5",
-            "--eoa-start", "103835740027347086785932208981225044632444623980288738833340492242305523519088",
+            "--eoa-start", eoa_start,
             "--skip-cleanup",
             args.test_path,
             "--",
@@ -1636,7 +1641,9 @@ def main():
         if eest_mode:
             uv_cmd.extend(["-m", eest_mode])
         if args.parameter_filter:
-            uv_cmd.extend(["-k", args.parameter_filter])
+            uv_cmd.extend(["-k", f"({args.parameter_filter}) and not {deployment_test_filter}"])
+        else:
+            uv_cmd.extend(["-k", f"not {deployment_test_filter}"])
         stubs_source = args.stubs_file or os.environ.get("EEST_ADDRESS_STUBS")
         if stubs_source:
             stubs_path = Path(stubs_source).expanduser()
@@ -1653,6 +1660,60 @@ def main():
         else:
             run_env["PYTHONPATH"] = src_path
         run_env["EEST_POLL_INTERVAL"] = "0.01"
+
+        if reuse_globals:
+            print("[INFO] Reusing existing global setup payloads; skipping contract deployment run.")
+        else:
+            deploy_cmd = [
+                "uv", "run", "execute", "remote", "-v",
+                f"--fork={args.fork}",
+                f"--rpc-seed-key={args.rpc_seed_key}",
+                f"--rpc-chain-id={chain_id}",
+                f"--rpc-endpoint={tests_rpc}",
+                "--gas-benchmark-values=1",
+                "--tx-wait-timeout", "5",
+                # Offset the EOA pool so deployment senders never collide
+                # with the senders the benchmark run derives.
+                "--eoa-start", str(int(eoa_start) + 10_000_000),
+                "--skip-cleanup",
+                args.test_path,
+                "--",
+                "-n", "1",
+                "-k", deployment_test_filter,
+            ]
+            print("[INFO] Deploying CREATE2 receiver contracts (global setup).")
+            print("\n[RUN] " + " ".join(deploy_cmd))
+            deploy_proc = subprocess.Popen(deploy_cmd, cwd=str(repo_dir), env=run_env)
+            deploy_tokens: set[str] = set()
+            try:
+                while True:
+                    payload = _read_json_file(pause_file) if pause_file.exists() else None
+                    if payload:
+                        token = str(payload.get("token") or "")
+                        if token and token not in deploy_tokens:
+                            scenario_name = payload.get("scenario") or "unknown"
+                            try:
+                                resume_file.unlink(missing_ok=True)
+                            except Exception:
+                                pass
+                            _write_resume_signal(resume_file, token, scenario_name)
+                            if not _wait_for_resume_consumed(resume_file, timeout=300.0):
+                                print(f"[WARN] Resume signal not consumed for {scenario_name} (token={token}) within timeout")
+                            deploy_tokens.add(token)
+                            continue
+                    if deploy_proc.poll() is not None:
+                        break
+                    time.sleep(0.1)
+            finally:
+                if deploy_proc.poll() is None:
+                    deploy_proc.terminate()
+                    try:
+                        deploy_proc.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        deploy_proc.kill()
+                        deploy_proc.wait()
+            if deploy_proc.returncode != 0:
+                raise subprocess.CalledProcessError(deploy_proc.returncode, deploy_cmd)
 
         testing_dir = payloads_dir / "testing"
         seen_testing_files: set[str] = set()

--- a/eest_stateful_generator.py
+++ b/eest_stateful_generator.py
@@ -599,6 +599,28 @@ def _promote_deploy_setup_to_global(payloads_dir: Path, setup_global_file: Path,
           "(predeployments now live in the base).")
     return True
 
+# Chainspec param whose timestamp activates each post-Osaka fork in Nethermind
+# (used to floor the benchmark phase's block timestamps past the transition).
+_FORK_TRANSITION_PARAM = {
+    "amsterdam": "eip7928TransitionTimestamp",  # AmsterdamTimestamp <- EIP-7928
+}
+
+def _fork_transition_timestamp(genesis_file: Path, fork: str) -> Optional[int]:
+    """Return the genesis-scheduled activation timestamp for *fork*, or None."""
+    key = _FORK_TRANSITION_PARAM.get(fork.lower())
+    if key is None:
+        return None
+    try:
+        params = json.loads(
+            Path(genesis_file).read_text(encoding="utf-8")
+        ).get("params", {})
+        val = params.get(key)
+        if val is None:
+            return None
+        return int(val, 16) if isinstance(val, str) else int(val)
+    except Exception:
+        return None
+
 def is_mounted(mount_point: Path) -> bool:
     try:
         with open("/proc/mounts", "r") as f:
@@ -1150,6 +1172,15 @@ def main():
     parser.add_argument("--sim-parallelism", type=int, default=1)
     parser.add_argument("--test-path", default="tests")
     parser.add_argument("--fork", default="Prague")
+    parser.add_argument(
+        "--benchmark-fork",
+        default=None,
+        help="Fork for the benchmark (second 'execute remote') phase. Defaults "
+        "to --fork. Set it to a later fork (e.g. Amsterdam while --fork=Osaka) "
+        "to fill the setup/prestate on --fork and the benchmarks on a later "
+        "fork; requires a genesis that schedules the later fork's transition "
+        "(its block timestamps are floored past that transition).",
+    )
     parser.add_argument("--rpc-endpoint", default=None)
     parser.add_argument("--seed-account-sweep-amount", default="1000 ether")
     parser.add_argument("--rpc-chain-id", type=int, default=None)
@@ -1608,6 +1639,29 @@ def main():
         print(f"[WARN] Finalized block {finalized_hash} not found; clearing anchor.")
         finalized_hash = ""
 
+    # Optional two-fork split: setup/prestate on --fork, benchmarks on a later
+    # fork scheduled in the genesis. The benchmark phase runs under a restarted
+    # mitm addon whose block timestamps are floored past the transition.
+    benchmark_fork = args.benchmark_fork or args.fork
+    benchmark_min_ts: Optional[int] = None
+    if benchmark_fork.lower() != args.fork.lower():
+        if genesis_file is None:
+            raise SystemExit(
+                "--benchmark-fork requires --genesis-path scheduling the "
+                "benchmark fork's transition."
+            )
+        benchmark_min_ts = _fork_transition_timestamp(genesis_file, benchmark_fork)
+        if benchmark_min_ts is None:
+            raise SystemExit(
+                f"--benchmark-fork={benchmark_fork} but genesis {genesis_file} "
+                "has no transition timestamp for it."
+            )
+        print(
+            f"[INFO] Two-fork run: setup/prestate on {args.fork}, benchmarks on "
+            f"{benchmark_fork} (benchmark block timestamps floored to "
+            f"{benchmark_min_ts})."
+        )
+
     mitm_config = {
         "rpc_direct": "http://127.0.0.1:8545",
         "engine_url": "http://127.0.0.1:8551",
@@ -1662,7 +1716,7 @@ def main():
         deployment_test_filter = "test_deploy_existing_contracts"
         uv_cmd = [
             "uv", "run", "execute", "remote", "-v",
-            f"--fork={args.fork}",
+            f"--fork={benchmark_fork}",
             f"--rpc-seed-key={args.rpc_seed_key}",
             f"--rpc-chain-id={chain_id}",
             f"--rpc-endpoint={tests_rpc}",
@@ -1773,6 +1827,48 @@ def main():
         seen_testing_files: set[str] = set()
         if testing_dir.exists():
             seen_testing_files = {f.stem for f in testing_dir.glob("*.txt") if f.is_file()}
+
+        # Two-fork split: restart the mitm addon for the benchmark phase so its
+        # blocks are built on the later fork (newPayload version) with
+        # timestamps floored past the genesis transition. The node keeps
+        # running; the benchmark scenarios re-derive their anchor from
+        # setup-global-test.txt on disk, which survives the restart.
+        if benchmark_fork.lower() != args.fork.lower():
+            print(
+                f"[INFO] Restarting mitm addon for benchmark phase: fork="
+                f"{benchmark_fork}, min_block_timestamp={benchmark_min_ts}."
+            )
+            benchmark_config = dict(mitm_config)
+            benchmark_config["fork"] = benchmark_fork
+            benchmark_config["min_block_timestamp"] = benchmark_min_ts
+            # The prestate (setup-global-test.txt) is already built by the
+            # deploy phase + promotion; mark globals as reusable so the
+            # restarted addon does NOT truncate it on startup and instead
+            # anchors the benchmark scenarios on the deploy head.
+            benchmark_config["reuse_globals"] = True
+            if benchmark_fork.lower() in ("amsterdam",):
+                benchmark_config["slot_counter_start"] = benchmark_min_ts // 12
+            else:
+                benchmark_config.pop("slot_counter_start", None)
+            old_mitm = CLEANUP.get("mitm")
+            if old_mitm is not None and old_mitm.poll() is None:
+                old_mitm.terminate()
+                try:
+                    old_mitm.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    old_mitm.kill()
+                    old_mitm.wait()
+            Path("mitm_config.json").write_text(
+                json.dumps(benchmark_config), encoding="utf-8"
+            )
+            mitm = start_mitm_proxy(
+                addon_path, listen_port=8549, upstream="http://127.0.0.1:8545"
+            )
+            CLEANUP["mitm"] = mitm
+            if not wait_for_port("127.0.0.1", 8549, timeout=30):
+                raise RuntimeError(
+                    "mitmproxy failed to rebind on 8549 after benchmark restart"
+                )
 
         tests_proc = subprocess.Popen(uv_cmd, cwd=str(repo_dir), env=run_env)
         processed_tokens: set[str] = set()

--- a/eest_stateful_generator.py
+++ b/eest_stateful_generator.py
@@ -1670,7 +1670,7 @@ def main():
                 f"--rpc-seed-key={args.rpc_seed_key}",
                 f"--rpc-chain-id={chain_id}",
                 f"--rpc-endpoint={tests_rpc}",
-                "--gas-benchmark-values=1",
+                "--gas-benchmark-values=1000",
                 "--tx-wait-timeout", "5",
                 # Offset the EOA pool so deployment senders never collide
                 # with the senders the benchmark run derives.

--- a/eest_stateful_generator.py
+++ b/eest_stateful_generator.py
@@ -1683,6 +1683,7 @@ def main():
             ]
             print("[INFO] Deploying CREATE2 receiver contracts (global setup).")
             print("\n[RUN] " + " ".join(deploy_cmd))
+            deploy_start = time.monotonic()
             deploy_proc = subprocess.Popen(deploy_cmd, cwd=str(repo_dir), env=run_env)
             deploy_tokens: set[str] = set()
             try:
@@ -1712,6 +1713,11 @@ def main():
                     except subprocess.TimeoutExpired:
                         deploy_proc.kill()
                         deploy_proc.wait()
+            deploy_elapsed = time.monotonic() - deploy_start
+            print(
+                f"[INFO] Contract deployment finished in {deploy_elapsed:.1f}s "
+                f"({deploy_elapsed / 60:.1f} min)."
+            )
             if deploy_proc.returncode != 0:
                 raise subprocess.CalledProcessError(deploy_proc.returncode, deploy_cmd)
 

--- a/mitm_addon.py
+++ b/mitm_addon.py
@@ -62,6 +62,12 @@ _NEWPAYLOAD_METHOD = _newpayload_method_for_fork(FORK)
 
 _IS_AMSTERDAM: bool = FORK.lower() in ("amsterdam",)
 
+# Floor for every built block's timestamp. Used to push the benchmark phase
+# past a genesis fork-transition timestamp (e.g. Amsterdam) so the setup phase
+# (built by a separate addon instance without this floor) stays on the earlier
+# fork while the benchmarks run on the later fork. 0 disables the floor.
+MIN_BLOCK_TIMESTAMP: int = int(_CFG.get("min_block_timestamp") or 0)
+
 _SLOT_COUNTER: int = int(_CFG.get("slot_counter_start") or 0)
 
 def _next_slot() -> str:
@@ -750,6 +756,10 @@ def _next_lifecycle_timestamp(parent_ts: int) -> int:
     # Safety: always keep timestamp valid vs chosen parent.
     if _LIFECYCLE_TS <= parent_ts:
         _LIFECYCLE_TS = parent_ts + 12
+    # Floor to the configured minimum (e.g. a genesis fork-transition
+    # timestamp), so every block this instance builds lands on/after it.
+    if MIN_BLOCK_TIMESTAMP and _LIFECYCLE_TS < MIN_BLOCK_TIMESTAMP:
+        _LIFECYCLE_TS = MIN_BLOCK_TIMESTAMP
     return _LIFECYCLE_TS
 
 

--- a/mitm_addon.py
+++ b/mitm_addon.py
@@ -753,18 +753,8 @@ def _next_lifecycle_timestamp(parent_ts: int) -> int:
     return _LIFECYCLE_TS
 
 
-def _read_hook_block_for_first_setup() -> Optional[str]:
-    # Preferred hook source: dedicated empty hook anchor.
-    hook_anchor = (HOOK_BLOCK or "").strip()
-    if hook_anchor:
-        return hook_anchor
-
-    # Fallback: funding anchor passed by generator config.
-    funding_anchor = (FINALIZED_BLOCK or "").strip()
-    if funding_anchor:
-        return funding_anchor
-
-    # Legacy fallback: derive hook from setup-global-test payload file.
+def _last_block_hash_in_setup_global() -> Optional[str]:
+    """Return the hash of the last newPayload block in setup-global-test.txt."""
     if not _SETUP_GLOBAL_FILE.exists():
         return None
     try:
@@ -790,6 +780,27 @@ def _read_hook_block_for_first_setup() -> Optional[str]:
     except Exception as e:
         _log(f"hook block read failed from {_SETUP_GLOBAL_FILE}: {e}")
         return None
+
+
+def _read_hook_block_for_first_setup() -> Optional[str]:
+    # Preferred hook source: dedicated empty hook anchor.
+    hook_anchor = (HOOK_BLOCK or "").strip()
+    if hook_anchor:
+        return hook_anchor
+
+    # Prefer the global-setup base head (e.g. predeployed contracts in
+    # setup-global-test.txt) so the first phased test block builds ON TOP of
+    # the deploy base rather than forking from funding and ignoring it.
+    global_head = _last_block_hash_in_setup_global()
+    if global_head:
+        return global_head
+
+    # Fallback: funding anchor passed by generator config.
+    funding_anchor = (FINALIZED_BLOCK or "").strip()
+    if funding_anchor:
+        return funding_anchor
+
+    return None
 
 
 def _append_line(path: pathlib.Path, line: str) -> None:


### PR DESCRIPTION
# What this adds on top of [PR 156](https://github.com/NethermindEth/gas-benchmarks/pull/156)

[PR 156](https://github.com/NethermindEth/gas-benchmarks/pull/156) generates the stateful benchmark payloads: `gas-bump` → `funding` → a
deploy phase (`test_deploy_existing_contracts`) → the measured benchmark run.
This branch extends that with:

1. **Deploy output becomes prestate.** The deploy phase's payloads are promoted
   into `setup-global-test.txt` (the base replayed before every test, like
   `gas-bump.txt` / `funding.txt`) instead of being a measured scenario, and the
   addon anchors benchmark scenarios on that deploy head. So predeployed
   contracts/EOAs exist *before* the measured run and the client under test does
   not deploy them during it (and therefore can't warm/cache them).

2. **Two-fork runs (`--benchmark-fork`).** Fill the setup/prestate on `--fork`
   and the benchmarks on a later fork. The mitm addon is restarted for the
   benchmark phase with a `min_block_timestamp` floor (read from the genesis
   fork-transition timestamp) so benchmark blocks land past the transition (and
   use the correct `engine_newPayload` version), while `reuse_globals` preserves
   the prestate across the restart. Omit `--benchmark-fork` → single-fork,
   unchanged behavior.

### Paired execution-specs changes (as changes to [PR 2947](https://github.com/LouisTsai-Csie/execution-specs/pull/9) (note: PR not to execution-specs but as PR on top of PR 2947 as PR 9))

- `test_deploy_existing_contracts` also creates **EIP-7702 delegate EOAs**
  (delegate `i` → `i`-th `EXISTING_CONTRACT_DIFF` contract) as part of the
  prestate.
- `helpers.py`: derivable `diff_delegate_authority(i)` /
  `diff_delegate_target(fork, i)` so any benchmark can target the delegates.
- New benchmark case `diff_to_delegated_contract_diff` that sends transfers to
  those prestate delegates.

## How to use

1. Check out: gas-benchmarks `inject-contract-deployments`, execution-specs
   `deployments`.
2. Provide a genesis scheduling the benchmark fork at a high timestamp `T`
   (e.g. Osaka@0, Amsterdam@`T` via `eip7928TransitionTimestamp` and the other
   Amsterdam EIP transitions; the generator reads `T` from the genesis).
3. Run:

```bash
python3 eest_stateful_generator.py \
  --fork Osaka --benchmark-fork Amsterdam \
  --genesis-path <osaka-amsterdam-transition>.json \
  --chain mainnet --rpc-chain-id 1 \
  --rpc-seed-key <key> --rpc-address <addr> \
  --test-path tests/benchmark/stateful/bloatnet/ \
  --parameter_filter diff_to_delegated_contract_diff \
  --eest_mode repricing \
  --gas-bump-count <N> --gas-benchmark-values <V> \
  --eest-no-pull
```

Flow: boot Nethermind on the transition genesis → gas-bump + funding (Osaka) →
deploy phase (Osaka): contracts + 7702 delegates promoted to the
`setup-global-test.txt` prestate → addon restarts for Amsterdam → benchmark
(Amsterdam): transfers to the delegated EOAs.

**Single-fork:** drop `--benchmark-fork` and use a normal (non-transition)
genesis; the run behaves like PR 156 plus the prestate-promotion change.
