### PR TITLE
fix: HTML report merge crash and harden result file handling

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# The modules under test (utils, report_html, ...) live at the repository root.
+# Put the root on sys.path so `import utils` resolves whether the suite is run
+# with `pytest` or `python -m pytest` from the repo root.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/merge-results.py
+++ b/merge-results.py
@@ -3,6 +3,7 @@
 
 import argparse
 import os
+import shutil
 
 import yaml
 from bs4 import BeautifulSoup
@@ -39,12 +40,12 @@ def main():
 
         # If the file is not in the first folder, copy it from the second folder
         if not os.path.exists(first_file):
-            os.system(f'cp {second_file} {output_file}')
+            shutil.copy(second_file, output_file)
             continue
 
         # If the file is not in the second folder, copy it from the first folder
         if not os.path.exists(second_file):
-            os.system(f'cp {first_file} {output_file}')
+            shutil.copy(first_file, output_file)
             continue
 
         # If the file is in both folders, merge them

--- a/report_html.py
+++ b/report_html.py
@@ -48,7 +48,7 @@ def get_html_report(client_results, clients, results_paths, test_cases, methods,
                         '</head>' +
                         '<body>'
                         '<h2>Computer Specs</h2>'
-                        '<pre">' + computer_spec + '</pre>')
+                        '<pre>' + computer_spec + '</pre>')
     csv_table = {}
     for client in clients:
         image_to_print = ''
@@ -98,8 +98,8 @@ def get_html_report(client_results, clients, results_paths, test_cases, methods,
                                  f'<td>{data[11]}</td>\n'
                                  f'<td>{data[12]}</td>\n</tr>\n')
         results_to_print += '\n'
-        results_to_print += ('</table>\n'
-                             '</tbody>\n')
+        results_to_print += ('</tbody>\n'
+                             '</table>\n')
 
     results_to_print += ('    <script>'
                          'function sortTable(n, table_name, nm) {'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+from bs4 import BeautifulSoup
+
+import utils
+
+
+def _report(client, values):
+    rows = "".join(f"<tr><td>{client}</td><td>{v}</td></tr>" for v in values)
+    return (
+        "<html><body>"
+        f'<table id="table_{client}">'
+        "<thead><tr><th>client</th><th>MGas/s</th></tr></thead>"
+        f"<tbody>{rows}</tbody>"
+        "</table></body></html>"
+    )
+
+
+def test_merge_html_stacks_rows_under_one_header():
+    # Same client's results from two report folders (same table id). Previously
+    # this raised IndexError (it searched for a <thread> tag that never exists),
+    # and even after that it nested <tr> inside <tr>. It should now stack the
+    # rows under a single header, producing valid HTML.
+    first = _report("nethermind", ["101.2", "98.7"])
+    second = _report("nethermind", ["100.1", "99.4"])
+
+    merged = utils.merge_html(first, second)
+    soup = BeautifulSoup(merged, "html.parser")
+    table = soup.find("table")
+
+    # exactly one header, not duplicated
+    assert len(table.find_all("thead")) == 1
+    # all four data rows are present, stacked in the body
+    body = table.find("tbody")
+    data_rows = body.find_all("tr")
+    assert len(data_rows) == 4
+    # no <tr> is nested inside another <tr> (valid table structure)
+    for row in table.find_all("tr"):
+        assert row.find("tr") is None
+    # values from both reports survived
+    text = table.get_text()
+    for v in ("101.2", "98.7", "100.1", "99.4"):
+        assert v in text
+
+
+def test_merge_html_handles_table_without_thead():
+    first = '<html><body><table id="t"><tbody><tr><td>a</td></tr></tbody></table></body></html>'
+    second = '<html><body><table id="t"><tbody><tr><td>b</td></tr></tbody></table></body></html>'
+    merged = utils.merge_html(first, second)  # must not crash without a <thead>
+    assert "a" in merged
+    assert "b" in merged

--- a/utils.py
+++ b/utils.py
@@ -736,11 +736,19 @@ def merge_html(first_data, second_data):
     # Merge the elements of the tables that has the same id on both HTML files
     for first_table, second_table in zip(first_soup.find_all('table'), second_soup.find_all('table')):
         if first_table['id'] == second_table['id']:
-            second_table.find_all('thread')[0].decompose()
-            # Only merge the elements of the table, not the table itself, Completely remove from second table thread,
-            # will be the same on both files
-            for first_element, second_element in zip(first_table.find_all('tr'), second_table.find_all('tr')):
-                first_element.append(second_element)
+            # The two tables are the same client's results from different report
+            # folders, so stack the second table's data rows under the first
+            # table's rows, sharing a single header. Remove the second header
+            # first (the tag is <thead>, not <thread>, and may be absent, so
+            # decompose every match rather than indexing [0], which raised
+            # IndexError and crashed the merge). Append the remaining rows into
+            # the first table's <tbody> instead of nesting <tr> inside <tr>.
+            for thead in second_table.find_all('thead'):
+                thead.decompose()
+            first_body = first_table.find('tbody')
+            target = first_body if first_body is not None else first_table
+            for row in second_table.find_all('tr'):
+                target.append(row)
 
 
     return first_soup.prettify()


### PR DESCRIPTION
Four fixes in the result-merging / report-generation path, plus the repo's first `tests/test_utils.py`.

1. **`merge_html` crashed, then produced broken HTML (`utils.py`).** It searched for a `<thread>` tag (not valid HTML; the tag is `<thead>`) and indexed `[0]`, so `find_all('thread')[0]` raised `IndexError` and crashed the merge. Beyond the crash, the row merge appended each second-table `<tr>` into the first table's `<tr>`, nesting rows and putting a data row inside `<thead>`. Since the merged tables are the same client's results from two report folders (each client has a unique `id="table_<client>"`), the intent is to stack rows under one header. This removes the duplicate `<thead>` (decomposing every match, so it also handles a table with none) and appends the second table's body rows into the first table's `<tbody>`, producing valid, correctly-stacked HTML.
2. **`merge-results.py`.** Replaced `os.system(f'cp {src} {dst}')` with `shutil.copy`, so paths with spaces or shell metacharacters are handled correctly.
3. **`report_html.py` tags.** Fixed a malformed `<pre">` tag (should be `<pre>`).
4. **`report_html.py` table close order.** The report emitted `</table>` before `</tbody>`; swapped them to close `</tbody>` then `</table>`.

Adds `tests/test_utils.py` (matching the naming of the existing suite) asserting the merged output has one header, all rows stacked in the body, and no nested `<tr>`, plus the no-`<thead>` case; a root `conftest.py` makes the top-level modules import under pytest. Run with `python -m pytest tests/test_utils.py -v`. Verified locally that the merged output renders as valid, correctly-stacked HTML.
